### PR TITLE
Add 2018-12 event: Rust 2018 Eve

### DIFF
--- a/_posts/2018-12-05-rust-2018-eve.md
+++ b/_posts/2018-12-05-rust-2018-eve.md
@@ -1,0 +1,32 @@
+---
+title: "Rust 2018 Eve"
+date: 2018-12-05 19:15:00 MEZ
+categories: meetup cologne
+links:
+    "Meetup.com": "https://www.meetup.com/de-DE/RustCologne/events/vnwndpyxqbhb/"
+    "Planning discussion on Github": "https://github.com/Rustaceans/rust-cologne/issues/70"
+location: c4
+---
+Join us on **Wednesday, December 5, 2018** at the C4
+to celebrate Rust 2018 Eve!
+Because the very next day, December 6,
+is the official release date for Rust 1.31
+-- the first stable version of Rust that gives you access to the 2018 Edition.
+
+*Not sure what "2018 Edition" means?
+Check out the post ["What is Rust 2018?"] for a general description,
+as well as the [Edition Guide] for an overview of major features since Rust 1.0.*
+
+["What is Rust 2018?"]: https://blog.rust-lang.org/2018/07/27/what-is-rust-2018.html
+[Edition Guide]:  https://rust-lang-nursery.github.io/edition-guide/rust-2018/index.html
+
+Opening at 19:15, we welcome anyone to join us in discussing Rust and related topics.
+
+We are looking forward to seeing you!
+
+Yours,
+Pascal and Florian
+
+- - -
+
+The meetup will be held in English, but a lot of attendees understand German, too.

--- a/_posts/2018-12-05-rust-2018-eve.md
+++ b/_posts/2018-12-05-rust-2018-eve.md
@@ -13,6 +13,10 @@ Because the very next day, December 6,
 is the official release date for Rust 1.31
 -- the first stable version of Rust that gives you access to the 2018 Edition.
 
+With this final release of Rust in 2018 the year itself is drawing to an end, too.
+As is our tradition,
+we'll be commemorating this with glühwein as well as other hot and cold beverages.
+
 *Not sure what "2018 Edition" means?
 Check out the post ["What is Rust 2018?"] for a general description,
 as well as the [Edition Guide] for an overview of major features since Rust 1.0.*


### PR DESCRIPTION
cf. #70 

Note that since the `talks` field is not set, it will render this on the website:

> We're currently looking for talks. [Help us!](https://github.com/Rustaceans/rust-cologne/issues/70)

We migth want to make this more explicit in other announcments.